### PR TITLE
Bugfix/test venv

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -55,7 +55,7 @@
       shell: cp -ar {{ project_root }}/venv/lib/python2.7/site-packages/django/contrib/admin/static/admin/ {{ project_root }}/public_html/static/admin 
 
     - name: Run first time init
-      shell: if [ -e {{ project_root }}/application/django_project/first_time_init.py ]; then {{ project_virtual_env }}/bin/python {{ project_root }}/application/django_project/first_time_init.py; fi
+      shell: if [ -e {{ project_root }}/application/django_project/first_time_init.py ]; then . {{ project_virtual_env }}/bin/activate && {{ project_virtual_env }}/bin/python {{ project_root }}/application/django_project/first_time_init.py; fi
 
     - name: set ALLOWED_HOSTS
       lineinfile: regexp='^ALLOWED_HOSTS'
@@ -78,13 +78,15 @@
              {{ project_root }}/node_modules/bower/bin/bower install
 
     - name: Sync django db
-      shell: DJANGO_SETTINGS_MODULE=django_project.settings_production
+      shell: . {{ project_virtual_env }}/bin/activate &&
+             DJANGO_SETTINGS_MODULE=django_project.settings_production
              {{ project_virtual_env }}/bin/python 
              {{ project_root }}/application/manage.py syncdb --noinput
       tags: db
 
     - name: Migrate django db
-      shell: DJANGO_SETTINGS_MODULE=django_project.settings_production
+      shell: . {{ project_virtual_env }}/bin/activate &&
+             DJANGO_SETTINGS_MODULE=django_project.settings_production
              {{ project_virtual_env }}/bin/python 
              {{ project_root }}/application/manage.py migrate
       when: project_uses_south
@@ -99,13 +101,15 @@
 
     - name: Update i18n
       shell: chdir={{ project_root }}/application/{{ project_name }}
+             . {{ project_virtual_env }}/bin/activate &&
              DJANGO_SETTINGS_MODULE=django_project.settings_production
-             {{ project_virtual_env }}/bin/python 
+             {{ project_virtual_env }}/bin/python
              {{ project_root }}/application/manage.py compilemessages
 
     - name: Run the tests
       shell: chdir={{ project_root }}/application/{{ project_name }}
-             {{ project_virtual_env }}/bin/python 
+             . {{ project_virtual_env }}/bin/activate &&
+             {{ project_virtual_env }}/bin/python
              {{ project_root }}/application/manage.py test {{ project_name }}
 
   handlers:

--- a/deploy.yml
+++ b/deploy.yml
@@ -15,7 +15,9 @@
     # FIXME: make this more elegant
     # update settings for staging if needed
     - name: update settings to staging if needed
-      shell: if test -e {{ project_root }}/application/django_project/settings_staging.py; then mv {{ project_root }}/application/django_project/settings_staging.py  {{ project_root }}/application/django_project/settings_production.py; fi
+      shell: if test -e {{ project_root }}/application/django_project/settings_staging.py; then
+             mv {{ project_root }}/application/django_project/settings_staging.py  {{ project_root }}/application/django_project/settings_production.py;
+             fi
       when: groups.staging is defined and inventory_hostname in groups.staging
       
     # only create db password if its not there already
@@ -24,6 +26,7 @@
       register: result
       ignore_errors: True
       tags: db
+
     - name: create db-password
       copy: src=../non-git-files/{{ inventory_hostname }}.db-password
             dest={{ project_root }}/application/django_project/db-password
@@ -55,7 +58,10 @@
       shell: cp -ar {{ project_root }}/venv/lib/python2.7/site-packages/django/contrib/admin/static/admin/ {{ project_root }}/public_html/static/admin 
 
     - name: Run first time init
-      shell: if [ -e {{ project_root }}/application/django_project/first_time_init.py ]; then . {{ project_virtual_env }}/bin/activate && {{ project_virtual_env }}/bin/python {{ project_root }}/application/django_project/first_time_init.py; fi
+      shell: if [ -e {{ project_root }}/application/django_project/first_time_init.py ]; then
+             . {{ project_virtual_env }}/bin/activate &&
+             {{ project_virtual_env }}/bin/python {{ project_root }}/application/django_project/first_time_init.py;
+             fi
 
     - name: set ALLOWED_HOSTS
       lineinfile: regexp='^ALLOWED_HOSTS'


### PR DESCRIPTION
pep8 tests failed because of old version installed globally (0.x.x), worked with venv and new version (1.5.x). So now it uses venv everywhere